### PR TITLE
bugfix: fix crash when metadata.title is None

### DIFF
--- a/pretty_history/prettyhist.py
+++ b/pretty_history/prettyhist.py
@@ -51,12 +51,11 @@ def get_dumping_dir() -> Path:
 
 
 def to_markdown_link(event: Visit) -> str:
-    if event.metadata is None:
-        return f"<{event.url}>"
     if "file://" in event.url:
         return f"*{clean(event.url.lstrip('file://'))}*"
-    if len(event.metadata.title) > 0:
+    if event.metadata is not None and event.metadata.title is not None and len(event.metadata.title) > 0:
         return f"[{clean(event.metadata.title)}]({clean_url(url=event.url)})"
+    return f"<{event.url}>"  # default
 
 
 def prettify(history_json: Path, dumping_folder: Optional[Path]) -> None:


### PR DESCRIPTION
when running on my history dump:

```
Traceback (most recent call last):
  File "/home/sean/.local/bin/prettyhist", line 8, in <module>
    sys.exit(main())
  File "/home/sean/.local/lib/python3.10/site-packages/pretty_histo
ry/main.py", line 31, in main
    prettyhist.prettify(
  File "/home/sean/.local/lib/python3.10/site-packages/pretty_history/prettyhist.py", line 71, in prettify
    page.dump(out_folder=out)
  File "/home/sean/.local/lib/python3.10/site-packages/pretty_history/prettyhist.py", line 97, in dump
    f"- {datetime.strftime(visit.dt, '%H:%M')} {to_markdown_link(visit)}"
  File "/home/sean/.local/lib/python3.10/site-packages/pretty_history/prettyhist.py", line 58, in to_markdown_link
    if len(event.metadata.title) > 0:
TypeError: object of type 'NoneType' has no len()
```

the `title` on `metadata` can be `None`, even when `metadata` itself is `None`, just adds an additional check to fix the crash

cool to see someone was able to figure out using the python library part of `browserexport`, Im always lazy writing up docs